### PR TITLE
Make runnable from root dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .gradle
 .idea
 build
+bisq-pricenode
+bisq-pricenode.bat
+lib
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,27 @@ To run a pricenode, you will need:
 
   - JDK 8 if you want to build and run a node locally.
   - The `tor` binary (e.g. `brew install tor`) if you want to run a hidden service locally.
+  
+## Building source code
+
+This repo has a dependency on git submodule [bisq](https://github.com/bisq-network/bisq).  There are two ways to clone it before it can be compiled:
+
+```
+# 1) Use the --recursive option in the clone command:
+$ git clone --recursive  https://github.com/bisq-network/bisq-pricenode.git
+
+# 2) Do a normal clone, and pull down the bisq repo dependency with two git submodule commands:
+$ git clone https://github.com/bisq-network/bisq-pricenode.git
+$ cd bisq-pricenode
+$ git submodule init
+$ git submodule update
+```
+
+To build:
+```
+$ ./gradlew clean build
+```
+
 
 ## How to deploy for production
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,6 @@ java {
     }
 }
 
-compileJava {
-    options.release = 11
-}
-
 jar.manifest.attributes(
         "Implementation-Title": project.name,
         "Implementation-Version": version

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'application'
+    alias(libs.plugins.osdetector)
     alias(libs.plugins.springboot)
 }
 
@@ -10,6 +11,7 @@ repositories {
 
 group 'bisq'
 
+apply plugin: 'com.google.osdetector'
 apply plugin: "org.springframework.boot"
 apply plugin: 'io.spring.dependency-management'
 
@@ -63,6 +65,51 @@ dependencies {
     testCompileOnly libs.lombok
     testImplementation libs.junit.jupiter
     testImplementation libs.mockito.core
+}
+
+assemble {
+    doLast {
+        // Copy generated bisq-pricenode scripts to project's root dir.
+        copy {
+            from layout.buildDirectory.dir('scripts')
+            into projectDir
+        }
+        // Copy zipped distribution libs to project's top-level lib dir.
+        copy {
+            def distFolderName = project.name + '-' + version
+            def distZipName = buildDir.name + '/distributions/' + distFolderName + '.zip'
+            from(zipTree(distZipName)) {
+                include "$distFolderName/lib/**"
+                eachFile { fcd ->
+                    fcd.relativePath = new RelativePath(true, fcd.relativePath.segments.drop(2))
+                }
+                includeEmptyDirs = false
+            }
+            into "${projectDir}/lib"
+        }
+        // Edit generated shell script so it expects to be executed in
+        // the project's root dir as opposed to a 'bin' subdirectory.
+        if (osdetector.os != 'windows') {
+            // Delete the windows .bat script, not the *nix script alone.
+            delete fileTree(dir: projectDir, include: 'bisq-*.bat')
+            // Reset APP_HOME variable in *nix script.
+            def nixScriptFile = file("${projectDir}/${project.name}")
+            def oldAppHome = 'APP_HOME=$( cd "${APP_HOME:-./}.." && pwd -P ) || exit'
+            def newAppHome = 'APP_HOME=$( cd "${APP_HOME:-./}" && pwd -P ) || exit'
+            nixScriptFile.text = nixScriptFile.text.replace(oldAppHome, newAppHome)
+        } else {
+            // Delete the *nix script, not the windows .bat script.
+            delete fileTree(dir: projectDir, include: 'bisq-*', exclude: '*.bat')
+            // Reset APP_HOME variable in windows .bat script.
+            def windowsScriptFile = file("${projectDir}/${project.name}.bat")
+            windowsScriptFile.text = windowsScriptFile.text.replace('set APP_HOME=%DIRNAME%..', 'set APP_HOME=%DIRNAME%')
+        }
+    }
+}
+
+clean.doFirst {
+    // Remove the project root level 'bisq-*' scripts and 'lib' dir generated at the end of the assemble task.
+    delete fileTree(dir: projectDir, include: 'bisq-*'), 'lib'
 }
 
 test {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ knowm-xchange-lib = { strictly = '5.0.13' }
 logback-lib = { strictly = '1.2.6' }
 lombok-lib = { strictly = '1.18.22' }
 mockito-lib = { strictly = '4.0.0' }
+osdetector-plugin-lib = { strictly = '1.7.0' }
 slf4j-lib = { strictly = '1.7.36' }
 spring-dependency-management-plugin-lib = { strictly = '1.0.12.RELEASE' }
 spring-plugin-lib = { strictly = '2.5.6' }
@@ -61,5 +62,6 @@ knowm-xchange-libs = [
 ]
 
 [plugins]
+osdetector = { id = 'com.google.osdetector', version.ref = 'osdetector-plugin-lib' }
 springboot = { id = 'org.springframework.boot', version.ref = 'spring-plugin-lib' }
 springdependency = { id = 'io.spring.dependency-management', version.ref = 'spring-dependency-management-plugin-lib' }


### PR DESCRIPTION
This change copies the build's distribution `bisq-pricenode` script & `lib` dir to the project root dir.
    
It follows the bisq repo build convention making all of its apps runnable from the bisq project root dir.  The customized assemble task is a bit messy, and will have to be copy/pasted into other build files for new repos pulled out of the original bisq repo.  (A re-usable gradle plugin for this task will probably be factored out of this build file's assemble task in another PR.)
