### PR TITLE
Fix plugin management spec in settings.gradle

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+    }
+    includeBuild('bisq-gradle')
+}
 rootProject.name = 'bisq-pricenode'
 includeBuild('bisq')
-includeBuild('bisq-gradle')


### PR DESCRIPTION
We're including the `bisq-gradle` plugin build, not a project build, and we must call `includeBuild('bisq-gradle')` on the `PluginManagementSpec` DSL, not the `Settings` DSL.

See https://docs.gradle.org/current/javadoc/org/gradle/plugin/management/PluginManagementSpec.html.

Resolves https://github.com/bisq-network/bisq-gradle/pull/2#issuecomment-1194466378.

Based on `main`.