### PR TITLE
Fix links in toplevel readme and docker scripts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "bisq"]
 	path = bisq
 	url = https://github.com/bisq-network/bisq.git
+	branch = main
 [submodule "bisq-gradle"]
 	path = bisq-gradle
 	url = https://github.com/bisq-network/bisq-gradle.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "bisq"]
 	path = bisq
 	url = https://github.com/bisq-network/bisq.git
-	branch = main
+	branch = master
 [submodule "bisq-gradle"]
 	path = bisq-gradle
 	url = https://github.com/bisq-network/bisq-gradle.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,4 @@
 [submodule "bisq-gradle"]
 	path = bisq-gradle
 	url = https://github.com/bisq-network/bisq-gradle.git
+	branch = main

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ $ ./gradlew clean build
 Run the one-command installer:
 
 ```bash
-curl -s https://raw.githubusercontent.com/bisq-network/bisq/master/pricenode/install_pricenode_debian.sh | sudo bash
+curl -s https://raw.githubusercontent.com/bisq-network/bisq-pricenode/main/scripts/install_pricenode_debian.sh | sudo bash
 ```
 
 At the end of the installer script, it should print your Tor onion hostname.
@@ -76,13 +76,13 @@ curl http://localhost:8080/info
 If you run a main pricenode, you also are obliged to activate the monitoring feed by running
 
 ```bash
-bash <(curl -s https://raw.githubusercontent.com/bisq-network/bisq/master/monitor/install_collectd_debian.sh)
+bash <(curl -s https://raw.githubusercontent.com/bisq-network/bisq-monitor/main/scripts/install_collectd_debian.sh)
 ```
 Follow the instruction given by the script and report your certificate to the [@bisq-network/monitoring](https://github.com/orgs/bisq-network/teams/monitoring-operators) team.
 
 Furthermore, you are obliged to provide network size data to the monitor by running
 ```bash
-curl -s https://raw.githubusercontent.com/bisq-network/bisq/master/pricenode/install_networksize_debian.sh | sudo bash
+curl -s https://raw.githubusercontent.com/bisq-network/bisq-pricenode/main/scripts/install_networksize_debian.sh | sudo bash
 ```
 
 ### Updating
@@ -94,7 +94,7 @@ Then build an updated pricenode:
 
 ## How to deploy elsewhere
 
- - [README-HEROKU.md](README-HEROKU.md)
+ - [docs/README-HEROKU.md](docs/README-HEROKU.md)
  - [docker/README.md](docker/README.md)
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     sudo \
     openjfx && rm -rf /var/lib/apt/lists/*
 
-RUN git clone https://github.com/bisq-network/pricenode.git
-WORKDIR /pricenode/
+RUN git clone https://github.com/bisq-network/bisq-pricenode.git
+WORKDIR /bisq-pricenode/
 RUN ./gradlew assemble
 
 COPY loop.sh start_node.sh start_tor.sh ./

--- a/docker/loop.sh
+++ b/docker/loop.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
+
+# Must be run from project directory.
+
+VERSION=$(tr -d '\n' < ./src/main/resources/version.txt)
+echo "bisq-pricenode version = $VERSION"
+JAR="./build/libs/bisq-pricenode-$VERSION.jar"
+echo "bisq-pricenode jar = $JAR"
+
 while true
 do
-echo `date`  "(Re)-starting node"
-java -jar ./build/libs/bisq-pricenode.jar 2 2
-echo `date` "node terminated unexpectedly!!"
+echo `date`  "(Re)-starting bisq-pricenode"
+java -jar $JAR 2 2
+echo `date` "Node terminated unexpectedly!!"
 sleep 3
 done


### PR DESCRIPTION
I forgot to update some `curl` and documentation links to point to this new repo.

I also set the git submodule branches:  `bisq = master`, `bisq-gradle = main`.