### PR TITLE
Feature/ars pricenode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ configurations.all {
 }
 
 dependencies {
+    implementation enforcedPlatform(project(':platform'))
+
     // We need three subprojects from includeBuild('bisq'), with some of their transitive dependencies.
     implementation 'bisq:assets'
     implementation 'bisq:common'

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -1,0 +1,9 @@
+plugins {
+    id 'java-platform'
+}
+
+dependencies {
+    constraints {
+        api 'com.google.guava:guava:30.1.1-jre'
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,4 +5,6 @@ pluginManagement {
     includeBuild('bisq-gradle')
 }
 rootProject.name = 'bisq-pricenode'
+
 includeBuild('bisq')
+include 'platform'

--- a/src/main/java/bisq/price/spot/providers/CryptoYa.java
+++ b/src/main/java/bisq/price/spot/providers/CryptoYa.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.price.spot.providers;
+
+import bisq.price.spot.ExchangeRate;
+import bisq.price.spot.ExchangeRateProvider;
+import bisq.price.util.cryptoya.CryptoYaMarketData;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.core.env.Environment;
+import org.springframework.http.RequestEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * CryptoYa is used only for Argentina Peso (ARS).
+ * Currency controls in the country forces a black market where the currency can be traded freely.
+ * Official and easily available rates cannot be trusted, therefore a specific fetch needs to be done
+ * for these scenarios.
+ * This ExchangeRateProvider provides a real market rate (black or "blue") for ARS/BTC
+ */
+@Component
+class CryptoYa extends ExchangeRateProvider {
+
+    private static final String ARS_BTC_URL = "https://criptoya.com/api/btc/ars/0.1";
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public CryptoYa(Environment env) {
+        super(env, "CRYPTOYA", "cryptoya", Duration.ofMinutes(1));
+    }
+
+    /**
+     *
+     * @return average price buy/sell price averaging different providers suported by cryptoya api
+     * which uses the free market (or blue, or unofficial) ARS price for BTC
+     */
+    @Override
+    public Set<ExchangeRate> doGet() {
+        Set<ExchangeRate> result = new HashSet<>();
+        String key = "ARS";
+        Double rate = getARSBlueMarketData().averageBlueRate();
+        if (rate > 0.0d) {
+            result.add(new ExchangeRate(
+                    key,
+                    BigDecimal.valueOf(rate),
+                    new Date(),
+                    this.getName()
+            ));
+        }
+        return result;
+    }
+
+    private CryptoYaMarketData getARSBlueMarketData() {
+        return restTemplate.exchange(
+                RequestEntity
+                        .get(UriComponentsBuilder
+                                .fromUriString(CryptoYa.ARS_BTC_URL).build()
+                                .toUri())
+                        .build(),
+                new ParameterizedTypeReference<CryptoYaMarketData>() {
+                }
+        ).getBody();
+    }
+}

--- a/src/main/java/bisq/price/util/cryptoya/CryptoYaMarketData.java
+++ b/src/main/java/bisq/price/util/cryptoya/CryptoYaMarketData.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.price.util.cryptoya;
+
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+@Getter
+@Setter
+public class CryptoYaMarketData {
+
+    private CryptoYaTicker argenbtc;
+    private CryptoYaTicker buenbit;
+    private CryptoYaTicker ripio;
+    private CryptoYaTicker ripioexchange;
+    private CryptoYaTicker satoshitango;
+    private CryptoYaTicker cryptomkt;
+    private CryptoYaTicker decrypto;
+    private CryptoYaTicker latamex;
+    private CryptoYaTicker bitso;
+    private CryptoYaTicker letsbit;
+    private CryptoYaTicker fiwind;
+    private CryptoYaTicker lemoncash;
+    private CryptoYaTicker bitmonedero;
+    private CryptoYaTicker belo;
+    private CryptoYaTicker tiendacrypto;
+    private CryptoYaTicker saldo;
+    private CryptoYaTicker kriptonmarket;
+    private CryptoYaTicker calypso;
+    private CryptoYaTicker bybit;
+    private CryptoYaTicker binance;
+
+    /**
+     *
+     * @return the avg ask price from all the exchanges that have updated ask prices (not older than 1 day)
+     *      if no market data available returns 0
+     */
+    public Double averageBlueRate() {
+        // filter more than 1 day old values with yesterday UTC timestamp
+        Long yesterdayTimestamp = Instant.now().minus(1, ChronoUnit.DAYS).getEpochSecond();
+        return streamLatestAvailableMarkets(yesterdayTimestamp).mapToDouble(CryptoYaTicker::getAsk)
+                .average()
+                .orElse(0.0d);
+    }
+
+    private Stream<CryptoYaTicker> streamLatestAvailableMarkets(Long startingTime) {
+        return Stream.of(argenbtc, buenbit, ripio, ripioexchange, satoshitango,
+                cryptomkt, decrypto, latamex, bitso, letsbit, fiwind,
+                lemoncash, bitmonedero, belo, tiendacrypto, saldo,
+                kriptonmarket, calypso, bybit, binance)
+                    .filter(Objects::nonNull)
+                    .filter(rate -> rate.getTime() > startingTime);
+    }
+}

--- a/src/main/java/bisq/price/util/cryptoya/CryptoYaTicker.java
+++ b/src/main/java/bisq/price/util/cryptoya/CryptoYaTicker.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.price.util.cryptoya;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CryptoYaTicker {
+
+    private Double ask;
+
+    private Double totalAsk;
+
+    private Double bid;
+
+    private Double totalBid;
+
+    private Integer time;
+
+}

--- a/src/test/java/bisq/price/spot/providers/CryptoYaTest.java
+++ b/src/test/java/bisq/price/spot/providers/CryptoYaTest.java
@@ -1,0 +1,33 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.price.spot.providers;
+
+import bisq.price.AbstractExchangeRateProviderTest;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.StandardEnvironment;
+
+@Slf4j
+public class CryptoYaTest extends AbstractExchangeRateProviderTest {
+
+    @Test
+    public void doGet_successfulCall() {
+        doGet_successfulCall(new CryptoYa(new StandardEnvironment()));
+    }
+
+}


### PR DESCRIPTION
Hi there! This is my first PR ever in the project, please be kind to review it and I'll be kind and happy to review your comments/feedback :)

**Brief**:

 Countries with currency controls declare exchange rates that cannot be trusted and therefore and extra effort is needed to source a price that is actually traded in the real/free market. This PR is the first change towards solving the issue for the currency ARS (Argentina Peso) -> it provides a price node exchange rate for ARS/BTC. 

There might be more PRs coming to use this price node and/or solve the problems for other countries like Lebanon.

** Approach **

CryptoYa public API was used as suggested in the related issue. It is possible to get rates from different exchanges that already work with the blue rate in Argentina. An Average algorithm was implemented taking the asking price from each of them that have been updated at least a day ago. The API seems quite reliable, but if any data issues were to happen defaults have been provided (any price, then 0.0 meaning "do not include / no data").

**Related Issues**:

 - This PR requires https://github.com/bisq-network/bisq-pricenode/pull/14.

- https://github.com/bisq-network/bisq/issues/6601 

**Testing**
 
 - A passing test is provided in this PR

** Other important notes **

When I started this the project was not compiling in main so this PR includes some code that quick-fixes this. I'm more than happy to review feedback on this and strip those changes out into a different PR if needed.

Hope you enjoy reviewing this code, thanks!