### PR TITLE
Update bisq module to 17abc0b

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ configurations.all {
 }
 
 dependencies {
+    implementation enforcedPlatform(project(':platform'))
+
     // We need three subprojects from includeBuild('bisq'), with some of their transitive dependencies.
     implementation 'bisq:assets'
     implementation 'bisq:common'

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -1,0 +1,9 @@
+plugins {
+    id 'java-platform'
+}
+
+dependencies {
+    constraints {
+        api 'com.google.guava:guava:30.1.1-jre'
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,4 +5,6 @@ pluginManagement {
     includeBuild('bisq-gradle')
 }
 rootProject.name = 'bisq-pricenode'
+
 includeBuild('bisq')
+include 'platform'


### PR DESCRIPTION
- Enforce bisq module Guava version

This PR requires https://github.com/bisq-network/bisq-pricenode/pull/14.