### PR TITLE
CryptoYa: Migrate to WebClient

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ dependencies {
         exclude group: 'ch.qos.logback'
         exclude group: 'org.slf4j'
     }
+    implementation(libs.spring.boot.starter.webflux)
 
     testAnnotationProcessor libs.lombok
     testCompileOnly libs.lombok

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,6 +47,7 @@ mockito-core = { module = 'org.mockito:mockito-core', version.ref = 'mockito-lib
 slf4j-api = { module = 'org.slf4j:slf4j-api', version.ref = 'slf4j-lib' }
 spring-dependency-management-plugin = { module = 'io.spring.gradle:dependency-management-plugin', version.ref = 'spring-dependency-management-plugin-lib' }
 spring-boot-starter-web = { module = 'org.springframework.boot:spring-boot-starter-web', version.ref = 'spring-boot-starter-web-lib' }
+spring-boot-starter-webflux = { module = 'org.springframework.boot:spring-boot-starter-webflux', version.ref = 'spring-boot-starter-web-lib' }
 
 [bundles]
 knowm-xchange-libs = [

--- a/src/main/java/bisq/price/spot/providers/CryptoYa.java
+++ b/src/main/java/bisq/price/spot/providers/CryptoYa.java
@@ -21,10 +21,12 @@ import bisq.price.spot.ExchangeRate;
 import bisq.price.spot.ExchangeRateProvider;
 import bisq.price.util.cryptoya.CryptoYaMarketData;
 import org.springframework.core.env.Environment;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.OptionalDouble;
 import java.util.Set;
@@ -41,7 +43,7 @@ class CryptoYa extends ExchangeRateProvider {
 
     private static final String CRYPTO_YA_BTC_ARS_API_URL = "https://criptoya.com/api/btc/ars/0.1";
 
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final WebClient webClient = WebClient.create();
 
     public CryptoYa(Environment env) {
         super(env, "CRYPTOYA", "cryptoya", Duration.ofMinutes(1));
@@ -65,6 +67,11 @@ class CryptoYa extends ExchangeRateProvider {
     }
 
     private CryptoYaMarketData fetchArsBlueMarketData() {
-        return restTemplate.getForObject(CRYPTO_YA_BTC_ARS_API_URL, CryptoYaMarketData.class);
+        return webClient.get()
+                .uri(CRYPTO_YA_BTC_ARS_API_URL)
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .bodyToMono(CryptoYaMarketData.class)
+                .block(Duration.of(30, ChronoUnit.SECONDS));
     }
 }

--- a/src/main/java/bisq/price/spot/providers/CryptoYa.java
+++ b/src/main/java/bisq/price/spot/providers/CryptoYa.java
@@ -56,7 +56,7 @@ class CryptoYa extends ExchangeRateProvider {
     public Set<ExchangeRate> doGet() {
         Set<ExchangeRate> result = new HashSet<>();
         String key = "ARS";
-        Double rate = getARSBlueMarketData().averageBlueRate();
+        Double rate = fetchArsBlueMarketData().averageBlueRate();
         if (rate > 0.0d) {
             result.add(new ExchangeRate(
                     key,
@@ -68,7 +68,7 @@ class CryptoYa extends ExchangeRateProvider {
         return result;
     }
 
-    private CryptoYaMarketData getARSBlueMarketData() {
+    private CryptoYaMarketData fetchArsBlueMarketData() {
         return restTemplate.getForObject(CRYPTO_YA_BTC_ARS_API_URL, CryptoYaMarketData.class);
     }
 }

--- a/src/main/java/bisq/price/spot/providers/CryptoYa.java
+++ b/src/main/java/bisq/price/spot/providers/CryptoYa.java
@@ -56,7 +56,7 @@ class CryptoYa extends ExchangeRateProvider {
     public Set<ExchangeRate> doGet() {
         Set<ExchangeRate> result = new HashSet<>();
         String key = "ARS";
-        Double rate = fetchArsBlueMarketData().averageBlueRate();
+        Double rate = fetchArsBlueMarketData().averagedArsBlueRateFromLast24Hours();
         if (rate > 0.0d) {
             result.add(new ExchangeRate(
                     key,

--- a/src/main/java/bisq/price/spot/providers/CryptoYa.java
+++ b/src/main/java/bisq/price/spot/providers/CryptoYa.java
@@ -28,6 +28,7 @@ import java.math.BigDecimal;
 import java.time.Duration;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.OptionalDouble;
 import java.util.Set;
 
 /**
@@ -56,11 +57,12 @@ class CryptoYa extends ExchangeRateProvider {
     public Set<ExchangeRate> doGet() {
         Set<ExchangeRate> result = new HashSet<>();
         String key = "ARS";
-        Double rate = fetchArsBlueMarketData().averagedArsBlueRateFromLast24Hours();
-        if (rate > 0.0d) {
+
+        OptionalDouble rate = fetchArsBlueMarketData().averagedArsBlueRateFromLast24Hours();
+        if (rate.isPresent()) {
             result.add(new ExchangeRate(
                     key,
-                    BigDecimal.valueOf(rate),
+                    BigDecimal.valueOf(rate.getAsDouble()),
                     new Date(),
                     this.getName()
             ));

--- a/src/main/java/bisq/price/spot/providers/CryptoYa.java
+++ b/src/main/java/bisq/price/spot/providers/CryptoYa.java
@@ -20,12 +20,9 @@ package bisq.price.spot.providers;
 import bisq.price.spot.ExchangeRate;
 import bisq.price.spot.ExchangeRateProvider;
 import bisq.price.util.cryptoya.CryptoYaMarketData;
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.env.Environment;
-import org.springframework.http.RequestEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import java.math.BigDecimal;
 import java.time.Duration;
@@ -52,7 +49,6 @@ class CryptoYa extends ExchangeRateProvider {
     }
 
     /**
-     *
      * @return average price buy/sell price averaging different providers suported by cryptoya api
      * which uses the free market (or blue, or unofficial) ARS price for BTC
      */
@@ -73,14 +69,6 @@ class CryptoYa extends ExchangeRateProvider {
     }
 
     private CryptoYaMarketData getARSBlueMarketData() {
-        return restTemplate.exchange(
-                RequestEntity
-                        .get(UriComponentsBuilder
-                                .fromUriString(CryptoYa.ARS_BTC_URL).build()
-                                .toUri())
-                        .build(),
-                new ParameterizedTypeReference<CryptoYaMarketData>() {
-                }
-        ).getBody();
+        return restTemplate.getForObject(ARS_BTC_URL, CryptoYaMarketData.class);
     }
 }

--- a/src/main/java/bisq/price/spot/providers/CryptoYa.java
+++ b/src/main/java/bisq/price/spot/providers/CryptoYa.java
@@ -40,7 +40,7 @@ import java.util.Set;
 @Component
 class CryptoYa extends ExchangeRateProvider {
 
-    private static final String ARS_BTC_URL = "https://criptoya.com/api/btc/ars/0.1";
+    private static final String CRYPTO_YA_BTC_ARS_API_URL = "https://criptoya.com/api/btc/ars/0.1";
 
     private final RestTemplate restTemplate = new RestTemplate();
 
@@ -69,6 +69,6 @@ class CryptoYa extends ExchangeRateProvider {
     }
 
     private CryptoYaMarketData getARSBlueMarketData() {
-        return restTemplate.getForObject(ARS_BTC_URL, CryptoYaMarketData.class);
+        return restTemplate.getForObject(CRYPTO_YA_BTC_ARS_API_URL, CryptoYaMarketData.class);
     }
 }

--- a/src/main/java/bisq/price/util/cryptoya/CryptoYaMarketData.java
+++ b/src/main/java/bisq/price/util/cryptoya/CryptoYaMarketData.java
@@ -56,7 +56,7 @@ public class CryptoYaMarketData {
      * @return the avg ask price from all the exchanges that have updated ask prices (not older than 1 day)
      *      if no market data available returns 0
      */
-    public Double averageBlueRate() {
+    public Double averagedArsBlueRateFromLast24Hours() {
         // filter more than 1 day old values with yesterday UTC timestamp
         Long yesterdayTimestamp = Instant.now().minus(1, ChronoUnit.DAYS).getEpochSecond();
         return streamLatestAvailableMarkets(yesterdayTimestamp).mapToDouble(CryptoYaTicker::getAsk)

--- a/src/main/java/bisq/price/util/cryptoya/CryptoYaMarketData.java
+++ b/src/main/java/bisq/price/util/cryptoya/CryptoYaMarketData.java
@@ -24,6 +24,7 @@ import lombok.Setter;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Objects;
+import java.util.OptionalDouble;
 import java.util.stream.Stream;
 
 @Getter
@@ -51,25 +52,22 @@ public class CryptoYaMarketData {
     private CryptoYaTicker bybit;
     private CryptoYaTicker binance;
 
-    /**
-     *
-     * @return the avg ask price from all the exchanges that have updated ask prices (not older than 1 day)
-     *      if no market data available returns 0
-     */
-    public Double averagedArsBlueRateFromLast24Hours() {
-        // filter more than 1 day old values with yesterday UTC timestamp
-        Long yesterdayTimestamp = Instant.now().minus(1, ChronoUnit.DAYS).getEpochSecond();
+    public OptionalDouble averagedArsBlueRateFromLast24Hours() {
+        Long yesterdayTimestamp = Instant.now()
+                .minus(1, ChronoUnit.DAYS)
+                .getEpochSecond();
+
         return streamLatestAvailableMarkets(yesterdayTimestamp).mapToDouble(CryptoYaTicker::getAsk)
-                .average()
-                .orElse(0.0d);
+                .average();
     }
 
     private Stream<CryptoYaTicker> streamLatestAvailableMarkets(Long startingTime) {
         return Stream.of(argenbtc, buenbit, ripio, ripioexchange, satoshitango,
-                cryptomkt, decrypto, latamex, bitso, letsbit, fiwind,
-                lemoncash, bitmonedero, belo, tiendacrypto, saldo,
-                kriptonmarket, calypso, bybit, binance)
-                    .filter(Objects::nonNull)
-                    .filter(rate -> rate.getTime() > startingTime);
+                        cryptomkt, decrypto, latamex, bitso, letsbit, fiwind,
+                        lemoncash, bitmonedero, belo, tiendacrypto, saldo,
+                        kriptonmarket, calypso, bybit, binance)
+                .filter(Objects::nonNull)
+                .filter(r -> r.getAsk() > 0)
+                .filter(rate -> rate.getTime() > startingTime);
     }
 }

--- a/src/main/java/bisq/price/util/cryptoya/CryptoYaMarketData.java
+++ b/src/main/java/bisq/price/util/cryptoya/CryptoYaMarketData.java
@@ -53,7 +53,7 @@ public class CryptoYaMarketData {
     private CryptoYaTicker binance;
 
     public OptionalDouble averagedArsBlueRateFromLast24Hours() {
-        Long yesterdayTimestamp = Instant.now()
+        long yesterdayTimestamp = Instant.now()
                 .minus(1, ChronoUnit.DAYS)
                 .getEpochSecond();
 

--- a/src/main/java/bisq/price/util/cryptoya/CryptoYaMarketData.java
+++ b/src/main/java/bisq/price/util/cryptoya/CryptoYaMarketData.java
@@ -62,12 +62,33 @@ public class CryptoYaMarketData {
     }
 
     private Stream<CryptoYaTicker> streamLatestAvailableMarkets(Long startingTime) {
-        return Stream.of(argenbtc, buenbit, ripio, ripioexchange, satoshitango,
-                        cryptomkt, decrypto, latamex, bitso, letsbit, fiwind,
-                        lemoncash, bitmonedero, belo, tiendacrypto, saldo,
-                        kriptonmarket, calypso, bybit, binance)
-                .filter(Objects::nonNull)
+        return allTickersAsStream().filter(Objects::nonNull)
                 .filter(r -> r.getAsk() > 0)
                 .filter(rate -> rate.getTime() > startingTime);
+    }
+
+    private Stream<CryptoYaTicker> allTickersAsStream() {
+        return Stream.of(
+                argenbtc,
+                buenbit,
+                ripio,
+                ripioexchange,
+                satoshitango,
+                cryptomkt,
+                decrypto,
+                latamex,
+                bitso,
+                letsbit,
+                fiwind,
+                lemoncash,
+                bitmonedero,
+                belo,
+                tiendacrypto,
+                saldo,
+                kriptonmarket,
+                calypso,
+                bybit,
+                binance
+        );
     }
 }

--- a/src/main/java/bisq/price/util/cryptoya/CryptoYaMarketData.java
+++ b/src/main/java/bisq/price/util/cryptoya/CryptoYaMarketData.java
@@ -57,14 +57,12 @@ public class CryptoYaMarketData {
                 .minus(1, ChronoUnit.DAYS)
                 .getEpochSecond();
 
-        return streamLatestAvailableMarkets(yesterdayTimestamp).mapToDouble(CryptoYaTicker::getAsk)
+        return allTickersAsStream()
+                .filter(Objects::nonNull)
+                .filter(rate -> rate.getTime() > yesterdayTimestamp)
+                .mapToDouble(CryptoYaTicker::getAsk)
+                .filter(ask -> ask > 0)
                 .average();
-    }
-
-    private Stream<CryptoYaTicker> streamLatestAvailableMarkets(Long startingTime) {
-        return allTickersAsStream().filter(Objects::nonNull)
-                .filter(r -> r.getAsk() > 0)
-                .filter(rate -> rate.getTime() > startingTime);
     }
 
     private Stream<CryptoYaTicker> allTickersAsStream() {

--- a/src/main/java/bisq/price/util/cryptoya/CryptoYaTicker.java
+++ b/src/main/java/bisq/price/util/cryptoya/CryptoYaTicker.java
@@ -32,6 +32,6 @@ public class CryptoYaTicker {
 
     private Double totalBid;
 
-    private Integer time;
+    private long time;
 
 }

--- a/src/main/java/bisq/price/util/cryptoya/CryptoYaTicker.java
+++ b/src/main/java/bisq/price/util/cryptoya/CryptoYaTicker.java
@@ -24,13 +24,13 @@ import lombok.Setter;
 @Setter
 public class CryptoYaTicker {
 
-    private Double ask;
+    private double ask;
 
-    private Double totalAsk;
+    private double totalAsk;
 
-    private Double bid;
+    private double bid;
 
-    private Double totalBid;
+    private double totalBid;
 
     private long time;
 


### PR DESCRIPTION
RestTemplate is getting deprecated in favor of WebClient, according to the documentation. Therefore, it's better to use the modern WebClient right from the start.

Based on #25 
Related to #15 