### PR TITLE
Remove AED price from Kraken

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,6 +8,6 @@ bisq.price.mining.providers.mempoolHostname.3=mempool.ninja
 bisq.price.mining.providers.mempoolHostname.4=mempool.bisq.services
 # bisq.price.mining.providers.mempoolHostname.5=someHostOrIP
 bisq.price.fiatcurrency.excluded=LBP
-bisq.price.fiatcurrency.excludedByProvider=HUOBI:BRL
+bisq.price.fiatcurrency.excludedByProvider=HUOBI:BRL,KRAKEN:AED
 bisq.price.cryptocurrency.excluded=
 bisq.price.outlierStdDeviation=1.1


### PR DESCRIPTION
Kraken removed AED market. Price shows 0.0 and needs removal.
Kraken website:
"ETH/AED is in cancel-only mode. You can't place any new orders but you can cancel existing ones."
Source: https://pro.kraken.com/app/trade/eth-aed