### PR TITLE
PriceProvider: Add volatile to cachedResult field

### DIFF
--- a/src/main/java/bisq/price/PriceProvider.java
+++ b/src/main/java/bisq/price/PriceProvider.java
@@ -39,7 +39,7 @@ public abstract class PriceProvider<T> implements SmartLifecycle, Supplier<T> {
 
     protected final Duration refreshInterval;
 
-    private T cachedResult;
+    private volatile T cachedResult;
 
     public PriceProvider(Duration refreshInterval) {
         this.refreshInterval = refreshInterval;


### PR DESCRIPTION
The get() and put() calls can happen on different threads. The volatile keyword makes sure that all updates to cachedResult are visible to all threads.

Relates to #33.