### PR TITLE
feature/add_etb_to_yadio_pricefeed

### DIFF
--- a/src/main/java/bisq/price/spot/providers/Yadio.java
+++ b/src/main/java/bisq/price/spot/providers/Yadio.java
@@ -50,6 +50,7 @@ import java.util.stream.Collectors;
  *  <ul>
  *      <li>ARS (Argentine Peso)</li>
  *      <li>LBP (Lebanese Pound)</li>
+ *      <li>ETB (Ethiopian Birr) — see bisq-network/bisq-mobile#1434</li>
  *  </ul>
  *
  * Further analysis could be made to incorporate more currencies like VES (Venezuela).
@@ -61,7 +62,7 @@ class Yadio extends ExchangeRateProvider implements BlueRateProvider {
 
     private static final String YADIO_EXCHANGES_API_ENDPOINT = "https://api.yadio.io/exrates";
 
-    private static final Set<String> YADIO_CURRENCIES_WHITELIST = Set.of("ARS", "BOB", "DOP", "EGP", "LBP", "PYG");
+    private static final Set<String> YADIO_CURRENCIES_WHITELIST = Set.of("ARS", "BOB", "DOP", "EGP", "ETB", "LBP", "PYG");
 
     private final WebClient webClient = WebClient.create();
 

--- a/src/test/java/bisq/price/spot/providers/YadioTest.java
+++ b/src/test/java/bisq/price/spot/providers/YadioTest.java
@@ -18,9 +18,16 @@
 package bisq.price.spot.providers;
 
 import bisq.price.AbstractExchangeRateProviderTest;
+import bisq.price.spot.ExchangeRate;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.env.StandardEnvironment;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @Slf4j
 public class YadioTest extends AbstractExchangeRateProviderTest {
@@ -28,6 +35,29 @@ public class YadioTest extends AbstractExchangeRateProviderTest {
     @Test
     public void doGet_successfulCall() {
         doGet_successfulCall(new Yadio(new StandardEnvironment()));
+    }
+
+    /**
+     * Pins the whitelist behavior for ETB (Ethiopian Birr) so that any future
+     * change accidentally removing it from {@code YADIO_CURRENCIES_WHITELIST}
+     * would be caught here.
+     * <p>
+     * Lives alongside {@link #doGet_successfulCall()} which is the broader
+     * smoke test. We tolerate the live Yadio API being unavailable (empty
+     * result) to avoid CI flakiness — when the API is reachable, ETB must
+     * be among the returned rates. See bisq-network/bisq-mobile#1434.
+     */
+    @Test
+    public void doGet_returnsETBWhenApiReachable() {
+        Set<ExchangeRate> rates = new Yadio(new StandardEnvironment()).doGet();
+        assumeFalse(rates.isEmpty(), "Yadio API returned no rates (likely network/API issue); skipping ETB assertion");
+
+        Set<String> currencies = rates.stream()
+                .map(ExchangeRate::getCurrency)
+                .collect(Collectors.toSet());
+
+        assertTrue(currencies.contains("ETB"),
+                "ETB should be among Yadio's returned rates. Actual currencies: " + currencies);
     }
 
 }


### PR DESCRIPTION
- contribs to https://github.com/bisq-network/bisq-mobile/issues/1434
- Add ETB (Ethiopian Birr) to Yadio price provider whitelist + test. api.yadio.io/exrates already returns the right blue market rates