### PR TITLE
feat: source XMR/BTC from liquid exchanges, add KuCoin

### DIFF
--- a/.github/workflows/api-liveness.yml
+++ b/.github/workflows/api-liveness.yml
@@ -16,9 +16,25 @@ jobs:
           - { name: coingecko,      url: 'https://api.coingecko.com/api/v3/exchange_rates' }
           - { name: yadio,          url: 'https://api.yadio.io/exrates' }
           - { name: poloniex,       url: 'https://api.poloniex.com/markets/price' }
-          # criptoya is intentionally omitted: it geoblocks non-LATAM IPs and returns
-          # 403 from GitHub-hosted runners, which would make this check permanently red.
-          # It is still covered by the local `liveTest` task.
+          # XChange-based exchange providers. The URL hit here is the public bulk
+          # endpoint each provider's XChange client relies on (instruments or
+          # all-tickers), so a non-2xx here flags upstream breakage the strict way.
+          - { name: kraken,         url: 'https://api.kraken.com/0/public/AssetPairs' }
+          - { name: kucoin,         url: 'https://api.kucoin.com/api/v1/market/allTickers' }
+          - { name: bitfinex,       url: 'https://api-pub.bitfinex.com/v2/tickers?symbols=ALL' }
+          - { name: bitstamp,       url: 'https://www.bitstamp.net/api/v2/ticker/' }
+          - { name: coinbasepro,    url: 'https://api.exchange.coinbase.com/products' }
+          - { name: bitflyer,       url: 'https://api.bitflyer.com/v1/ticker' }
+          - { name: btcmarkets,     url: 'https://api.btcmarkets.net/v3/markets/tickers?marketId=BTC-AUD' }
+          - { name: coinone,        url: 'https://api.coinone.co.kr/ticker?currency=all' }
+          - { name: indepreserve,   url: 'https://api.independentreserve.com/Public/GetValidPrimaryCurrencyCodes' }
+          - { name: luno,           url: 'https://api.luno.com/api/1/tickers' }
+          - { name: paribu,         url: 'https://www.paribu.com/ticker' }
+          # binance and mercadobitcoin are intentionally omitted: binance returns
+          # HTTP 451 (legal geoblock) and mercadobitcoin HTTP 403 to GitHub-hosted
+          # runners, which would make these checks permanently red. criptoya is
+          # likewise omitted: it geoblocks non-LATAM IPs and returns 403. All three
+          # remain covered by the local `liveTest` task.
           - { name: bluelytics,     url: 'https://api.bluelytics.com.ar/v2/latest' }
           - { name: mempool-space,  url: 'https://mempool.space/api/v1/fees/recommended' }
           - { name: mempool-emzy,   url: 'https://mempool.emzy.de/api/v1/fees/recommended' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ known-xchange-coinbasepro = { module = 'org.knowm.xchange:xchange-coinbasepro', 
 known-xchange-coinone = { module = 'org.knowm.xchange:xchange-coinone', version.ref = 'knowm-xchange-lib' }
 known-xchange-independentreserve = { module = 'org.knowm.xchange:xchange-independentreserve', version.ref = 'knowm-xchange-lib' }
 known-xchange-kraken = { module = 'org.knowm.xchange:xchange-kraken', version.ref = 'knowm-xchange-lib' }
+known-xchange-kucoin = { module = 'org.knowm.xchange:xchange-kucoin', version.ref = 'knowm-xchange-lib' }
 known-xchange-luno = { module = 'org.knowm.xchange:xchange-luno', version.ref = 'knowm-xchange-lib' }
 known-xchange-mercadobitcoin = { module = 'org.knowm.xchange:xchange-mercadobitcoin', version.ref = 'knowm-xchange-lib' }
 known-xchange-paribu = { module = 'org.knowm.xchange:xchange-paribu', version.ref = 'knowm-xchange-lib' }
@@ -39,7 +40,8 @@ knowm-xchange-libs = [
     'known-xchange-bitflyer', 'known-xchange-bitstamp', 'known-xchange-btcmarkets',
     'known-xchange-coinbasepro', 'known-xchange-coinone',
     'known-xchange-independentreserve',
-    'known-xchange-kraken', 'known-xchange-luno', 'known-xchange-mercadobitcoin', 'known-xchange-paribu'
+    'known-xchange-kraken', 'known-xchange-kucoin', 'known-xchange-luno',
+    'known-xchange-mercadobitcoin', 'known-xchange-paribu'
 ]
 
 [plugins]

--- a/src/main/java/bisq/price/spot/providers/KuCoin.java
+++ b/src/main/java/bisq/price/spot/providers/KuCoin.java
@@ -20,7 +20,7 @@ package bisq.price.spot.providers;
 import bisq.price.spot.ExchangeRate;
 import bisq.price.spot.ExchangeRateProvider;
 
-import org.knowm.xchange.binance.BinanceExchange;
+import org.knowm.xchange.kucoin.KucoinExchange;
 
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
@@ -30,19 +30,16 @@ import java.time.Duration;
 import java.util.Set;
 
 @Component
-class Binance extends ExchangeRateProvider implements BlueRateProvider {
+class KuCoin extends ExchangeRateProvider {
 
-    public Binance(Environment env) {
-        super(env, "BINANCE", "binance", Duration.ofMinutes(1));
+    public KuCoin(Environment env) {
+        super(env, "KUCOIN", "kucoin", Duration.ofMinutes(1));
     }
 
     @Override
     public Set<ExchangeRate> doGet() {
-        // Supported fiat: EUR, GBP, NGN, RUB, TRY, UAH, ZAR
-        // Supported alts: BEAM, DAI, DASH, DOGE, ETC, ETH, LTC, NAV, PIVX, XZC,
-        // ZEC, ZEN
-        // Note: XMR was delisted by Binance (Feb 2024), so the bulk ticker no
-        // longer returns an XMR/BTC pair and this provider contributes no XMR rate.
-        return doGet(BinanceExchange.class);
+        // Added as a liquid XMR/BTC source (alongside Kraken and Bitfinex),
+        // replacing the thin Poloniex book and the delisted Binance pair.
+        return doGet(KucoinExchange.class);
     }
 }

--- a/src/main/java/bisq/price/spot/providers/Poloniex.java
+++ b/src/main/java/bisq/price/spot/providers/Poloniex.java
@@ -34,8 +34,11 @@ import java.util.stream.Collectors;
 
 @Component
 class Poloniex extends ExchangeRateProvider {
+    // XMR intentionally excluded: Poloniex's XMR/BTC book is thin, so under
+    // volatility its rate can go stale/diverge and skew the aggregate average.
+    // XMR/BTC is sourced from the more liquid Kraken, Bitfinex and KuCoin instead.
     private static final List<String> SUPPORTED_CURRENCIES =
-            List.of("DASH", "DOGE", "ETC", "ETH", "LTC", "XMR", "ZEC");
+            List.of("DASH", "DOGE", "ETC", "ETH", "LTC", "ZEC");
     private static final String POLONIEX_URL = "https://api.poloniex.com/markets/price";
     private static final String PROVIDER_NAME = "POLO";
     public Poloniex(Environment env) {

--- a/src/test/java/bisq/price/spot/providers/KuCoinTest.java
+++ b/src/test/java/bisq/price/spot/providers/KuCoinTest.java
@@ -1,0 +1,33 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.price.spot.providers;
+
+import bisq.price.AbstractExchangeRateProviderTest;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.StandardEnvironment;
+
+@Slf4j
+public class KuCoinTest extends AbstractExchangeRateProviderTest {
+
+    @Test
+    public void doGet_successfulCall() {
+        doGet_successfulCall(new KuCoin(new StandardEnvironment()));
+    }
+
+}

--- a/src/test/java/bisq/price/spot/providers/LiveProvidersIT.java
+++ b/src/test/java/bisq/price/spot/providers/LiveProvidersIT.java
@@ -60,7 +60,7 @@ public class LiveProvidersIT {
         return Stream.of(
                 new Binance(ENV), new Bitfinex(ENV), new Bitflyer(ENV), new Bitstamp(ENV),
                 new BTCMarkets(ENV), new CoinbasePro(ENV), new Coinone(ENV),
-                new IndependentReserve(ENV), new Kraken(ENV), new Luno(ENV),
+                new IndependentReserve(ENV), new Kraken(ENV), new KuCoin(ENV), new Luno(ENV),
                 new MercadoBitcoin(ENV), new Paribu(ENV),
                 new CoinGecko(ENV), new Poloniex(ENV), new Yadio(ENV), new CryptoYa(ENV)
         ).map(p -> Arguments.of(p.getName(), p));


### PR DESCRIPTION
XMR/BTC aggregate averaged across all providers reporting XMR. Two of them are poor sources: Binance delisted XMR (Feb 2024) so contributes nothing, and Poloniex's XMR/BTC book is thin: under volatility its rate can go stale/diverge and skew the average.

- Add KuCoin provider (liquid XMR/BTC, plus its other supported pairs)
- Drop XMR from Poloniex's supported set (thin book)
- Fix stale Binance comment (XMR delisted, no longer returned)
- Cover KuCoin in mocked unit test and live integration sweep
- Add KuCoin + remaining reachable XChange endpoints to the strict api-liveness workflow (binance/mercadobitcoin omitted: geoblocked)

XMR/BTC now averages Kraken + Bitfinex + KuCoin. Verified live: KuCoin returns XMR (0.005438, tracking peers), Poloniex no longer emits XMR.