### PR TITLE
Remove inactive altcoins from the price feed

### DIFF
--- a/src/main/java/bisq/price/common/CurrencyUtil.java
+++ b/src/main/java/bisq/price/common/CurrencyUtil.java
@@ -24,18 +24,7 @@ import java.util.Set;
 @Slf4j
 public class CurrencyUtil {
     public static final Set<String> ALL_CRYPTO_CURRENCIES = Set.of(
-            "ACM", "ADE", "AEON", "AMIT", "ANI", "ARQ", "ASK", "AEUR", "AUS", "BSQ",
-            "BEAM", "DARX", "BTM", "BZC", "BLUR", "BLK-BURNT", "CRCL", "CTSC", "CASH2", "CHA",
-            "CLOAK", "XCP", "CRDS", "CROAT", "DST", "DAI", "D4RK", "DASH", "ONION",
-            "DXO", "DOGE", "DOI", "DONU", "DRGL", "EMC", "ERG", "ETH", "ETC", "ETHS",
-            "FAIR", "FRTY", "FJC", "GALI", "GMCN", "GENX", "GRIN", "HATCH", "HLM", "ZEN",
-            "IDA", "IRD", "KEK", "KYDC", "KORE", "ZOD", "LBC", "L-BTC", "LTC", "LCP",
-            "LTZ", "LYTX", "MSR", "MASK", "MILE", "MQX", "MOX", "MBGL", "XMR", "MUE",
-            "YCE", "NMC", "NAV", "NOR", "NTBC", "PENG", "PIVX", "PZDC", "PARS", "PART",
-            "PRSN", "PINK", "PLE", "QMCoin", "QBS", "QWC", "R-BTC", "RADS", "RMX", "RYO",
-            "SUB1X", "SCP", "SF", "SIL", "XSL", "SPACE", "XSPEC", "USDH", "USDT-E", "TUSD",
-            "TEO", "TRTL", "USDC", "UCC", "UNO", "VARIUS", "VXV", "VEIL", "VTC", "WORX",
-            "WEB", "WRKZ", "XDR0", "XRC", "ZEC", "XZC", "ZEL", "ZER", "ZERC", "XND", "UPX"
+            "BSQ", "DAI", "ETH", "LTC", "USDT-E", "USDC", "XMR"
     );
 
     public static final Set<String> ALL_FIAT_CURRENCIES = Set.of(

--- a/src/main/java/bisq/price/spot/providers/Binance.java
+++ b/src/main/java/bisq/price/spot/providers/Binance.java
@@ -39,8 +39,7 @@ class Binance extends ExchangeRateProvider implements BlueRateProvider {
     @Override
     public Set<ExchangeRate> doGet() {
         // Supported fiat: EUR, GBP, NGN, RUB, TRY, UAH, ZAR
-        // Supported alts: BEAM, DAI, DASH, DOGE, ETC, ETH, LTC, NAV, PIVX, XZC,
-        // ZEC, ZEN
+        // Supported alts: ETH, LTC, USDC, USDT-E
         // Note: XMR was delisted by Binance (Feb 2024), so the bulk ticker no
         // longer returns an XMR/BTC pair and this provider contributes no XMR rate.
         return doGet(BinanceExchange.class);

--- a/src/main/java/bisq/price/spot/providers/Bitfinex.java
+++ b/src/main/java/bisq/price/spot/providers/Bitfinex.java
@@ -39,7 +39,7 @@ class Bitfinex extends ExchangeRateProvider {
     @Override
     public Set<ExchangeRate> doGet() {
         // Supported fiat: EUR, GBP, JPY, USD
-        // Supported alts: DAI, ETC, ETH, LTC, XMR, ZEC
+        // Supported alts: DAI, ETH, LTC, XMR
         return doGet(BitfinexExchange.class);
     }
 }

--- a/src/main/java/bisq/price/spot/providers/CoinbasePro.java
+++ b/src/main/java/bisq/price/spot/providers/CoinbasePro.java
@@ -38,7 +38,7 @@ class CoinbasePro extends ExchangeRateProvider {
     @Override
     public Set<ExchangeRate> doGet() {
         // Supported fiat: EUR, USD, GBP
-        // Supported alts: DASH, DOGE, ETC, ETH, LTC, ZEC, ZEN
+        // Supported alts: ETH, LTC
         return doGet(CoinbaseProExchange.class);
     }
 

--- a/src/main/java/bisq/price/spot/providers/Kraken.java
+++ b/src/main/java/bisq/price/spot/providers/Kraken.java
@@ -39,7 +39,7 @@ class Kraken extends ExchangeRateProvider {
     @Override
     public Set<ExchangeRate> doGet() {
         // Supported fiat: AUD, CAD, CHF, EUR, GBP, JPY, USD
-        // Supported alts: DASH, DOGE, ETC, ETH, LTC, XMR, ZEC
+        // Supported alts: DAI, ETH, LTC, USDC, USDT-E, XMR
         return doGet(KrakenExchange.class);
     }
 

--- a/src/main/java/bisq/price/spot/providers/Poloniex.java
+++ b/src/main/java/bisq/price/spot/providers/Poloniex.java
@@ -38,7 +38,7 @@ class Poloniex extends ExchangeRateProvider {
     // volatility its rate can go stale/diverge and skew the aggregate average.
     // XMR/BTC is sourced from the more liquid Kraken, Bitfinex and KuCoin instead.
     private static final List<String> SUPPORTED_CURRENCIES =
-            List.of("DASH", "DOGE", "ETC", "ETH", "LTC", "ZEC");
+            List.of("ETH", "LTC");
     private static final String POLONIEX_URL = "https://api.poloniex.com/markets/price";
     private static final String PROVIDER_NAME = "POLO";
     public Poloniex(Environment env) {
@@ -74,7 +74,7 @@ class Poloniex extends ExchangeRateProvider {
         }
 
         public String getCurrency() {
-            // DASH_BTC, DOGE_BTC, LTC_BTC, ...
+            // ETH_BTC, LTC_BTC, ...
             return symbol.split("_")[0];
         }
 


### PR DESCRIPTION
Part of https://github.com/bisq-network/bisq2/issues/4153

Removes the altcoins without recent Bisq trade activity from the price feed. The evaluation behind the keep/drop split is in [this comment](https://github.com/bisq-network/bisq2/issues/4153#issuecomment-4980364222) (parsed from the full Bisq 1 trade statistics store, 404k trades) and the dependency check in [this one](https://github.com/bisq-network/bisq2/issues/4153#issuecomment-5001032195): production nodes already serve no rate for 107 of the removed codes, so for those nothing changes at all.

## Changes

- `CurrencyUtil.ALL_CRYPTO_CURRENCIES` trimmed from 120 codes to the 7 with trades in the last 24 months: XMR, BSQ, ETH, LTC, USDT-E, USDC, DAI. The two borderline codes from the evaluation (DOGE and SIL, one trade each in the last 12 months) are included in the removal.
- `Poloniex.SUPPORTED_CURRENCIES` trimmed to ETH and LTC, the rest of its list were removed codes.
- Stale "Supported alts" comments in Binance, Bitfinex, CoinbasePro and Kraken updated to what those providers actually serve from the kept set (taken from a local run's per-provider logs).

This PR only removes codes. Possible additions (a plain `USDT` entry for Bisq 2 came up in the issue) are left out until the scope question there is answered; adding USDT would also need a decision on the existing `USDT` to `USDT-E` translation in `ExchangeRateProvider`, so it is better done separately.

## Testing

Tested the trimmed list locally against a real Bisq 1 client:

- Ran this branch locally (`java -jar build/libs/bisq-pricenode-*.jar`, port 8080). `/getAllMarketPrices` serves 70 codes: the fiat set is unaffected, and of the kept altcoins DAI, ETH, LTC, USDC, USDT-E and XMR have live rates. None of the 113 removed codes appear (checked programmatically against the full old list, not by sampling). BSQ serves no rate, same as the production nodes, since no provider implements it.
- Started a Bisq 1 desktop client (current main, fresh data dir) with `--providers=http://localhost:8080/`. The client picked up the local node and showed market prices for fiat and the kept altcoins.
- Checked a removed coin (DASH) in the client: the price display falls back to "Price of latest Bisq trade" (trade statistics fallback, `isExternallyProvidedPrice=false`), with no price related errors or retry spam in the log. Percentage-price offers stay unavailable for such coins because `MarketPrice.isRecentExternalPriceAvailable()` requires an externally provided price; fixed-price offers do not consult the market price at all (the price comes from the offer itself via `Offer.getPrice()`), so they are unaffected. This is the behaviour these coins already get from production nodes today.
- Full `./gradlew build` incl. tests green.

## Remark

Side observation from the local run, pre-existing and not touched here: the Bitfinex provider fails every refresh with "Could not convert ticker" and CoinbasePro with "Coinbase Pro API is deprecated" (Coinbase shut that API down), so neither currently contributes any rate. Can file a separate issue for those if wanted.
